### PR TITLE
Prevent break of gulp task on SASS errors

### DIFF
--- a/generators/app/templates/gulp/tasks/sass.js
+++ b/generators/app/templates/gulp/tasks/sass.js
@@ -13,7 +13,7 @@ import config from '../config';
 gulp.task( 'styles', ()=> {
   return gulp.src( './src/scss/main.scss' )
     .pipe(plumber())
-    .pipe( sass() )
+    .pipe( sass.sync() )
     .pipe( cmq() )
     .pipe( autoprefixer( 'last 2 versions', 'ie9' ) )
     .pipe( rename( 'styles.min.css' ) )


### PR DESCRIPTION
Related to this `gulp-plumber` issue: https://github.com/floatdrop/gulp-plumber/issues/32
Without this fix, gulp watch task breaks when compiler does.